### PR TITLE
chore: update documentation to reflect new data return

### DIFF
--- a/docs/Endorsement API/BastionEndorseWebAPI_v2.md
+++ b/docs/Endorsement API/BastionEndorseWebAPI_v2.md
@@ -629,13 +629,58 @@ GET /api/v2/enrollee-auth-status?memberId=100004976
     "success": 1,
     "message": "Member Auth Status Details.",
     "member_auth": {
-      "auth_number": "3000XXXXX",
-      "message": "Dear Johm  Doe, an auth request 3000XXXXX from null, 1999-01-01 has been submitted for approval."
+      "member_name": "John  Doe",
+      "provider_name": "ABC Hospital",
+      "auth_number": "30000XXXX",
+      "auth_type": "OP",
+      "admission_date": null,
+      "discharge_date": null,
+      "service_date": "2026-04-16",
+      "admission_days": "null",
+      "status": "Approved",
+      "message": "Member Name: John  Doe\\nProvider: ABC Hospital\\nAuthorization Number: 30000XXXX\\nAuth Type: OP\\nAdmission Date: null\\nDischarge Date: null\\nService Date: 2026-04-16\\nDays Admitted: null\\nStatus: Approved"
     }
   }
 }
 ```
 
+**Example Usage**
+```http
+GET /api/v2/enrollee-auth-status?memberId=100004976&page=6&limit=3
+```
+
+**Example Response:**
+
+```json
+{
+  "status": true,
+  "data": {
+    "success": 1,
+    "message": "Member Auth Status Details.",
+    "member_auth": {
+      "member_name": "John  Doe",
+      "provider_name": "ABC Hospital",
+      "auth_number": "30000XXXX",
+      "auth_type": "OP",
+      "admission_date": null,
+      "discharge_date": null,
+      "service_date": "2026-04-16",
+      "admission_days": "null",
+      "status": "Approved",
+      "message": "Member Name: John  Doe\\nProvider: ABC Hospital\\nAuthorization Number: 30000XXXX\\nAuth Type: OP\\nAdmission Date: null\\nDischarge Date: null\\nService Date: 2026-04-16\\nDays Admitted: null\\nStatus: Approved"
+    }
+  },
+  "pagination": {
+    "current_page": 5,
+    "per_page": 3,
+    "total_records": 14,
+    "total_pages": 5,
+    "has_next": false,
+    "has_prev": true,
+    "from": 13,
+    "to": 14
+  }
+}
 ---
 
 ### 3.11 `Undo Multiple Deleted Member Endorsement`


### PR DESCRIPTION
This pull request updates the documentation for the `GET /api/v2/enrollee-auth-status` endpoint to provide a more detailed example response and clarify usage, including support for pagination. The changes improve the completeness and clarity of the API documentation.

**API response improvements:**

* Expanded the `member_auth` object in the example response to include additional fields such as `member_name`, `provider_name`, `auth_type`, `service_date`, `admission_days`, and `status`, providing a more comprehensive view of the authorization status.
* Updated the `message` field in the `member_auth` object to include all relevant details in a structured format.

**Pagination documentation:**

* Added an example usage with pagination parameters (`page` and `limit`) and included a sample paginated response, detailing the `pagination` object with fields like `current_page`, `per_page`, `total_records`, `total_pages`, `has_next`, and `has_prev`.